### PR TITLE
Added directive client_max_body_size to nginx.conf

### DIFF
--- a/generators/app/features/php-fpm-nginx/templates/.docker/[instances.web.name]/nginx.conf.mo.hbs
+++ b/generators/app/features/php-fpm-nginx/templates/.docker/[instances.web.name]/nginx.conf.mo.hbs
@@ -1,6 +1,7 @@
 server {
     root /var/www/html/{{instances.web.name}};
     index index.html index.php;
+    client_max_body_size 0;
 
     location ~ '\.php$' {
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;


### PR DESCRIPTION
Nginx has a directive for request body size set by default to 1Mo which conflicts with PHP settings for max_upload_size. Set this directive to 0 to bypass this funcitionnality (only for dev purpose)